### PR TITLE
[#1] Add conversion examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ newtype Size = Size { unSize :: Int }
 **Elm**
 
 ```elm
-type alias Size
+type alias Size =
     { unSize : Int
     }
 ```

--- a/README.md
+++ b/README.md
@@ -5,4 +5,117 @@
 [![Stackage Lts](http://stackage.org/package/elm-street/badge/lts)](http://stackage.org/lts/package/elm-street)
 [![Stackage Nightly](http://stackage.org/package/elm-street/badge/nightly)](http://stackage.org/nightly/package/elm-street)
 
-Crossing the road between Haskell and Elm
+Crossing the road between Haskell and Elm.
+
+## Examples
+
+Below you can see some examples of how Haskell data type are converted to Elm
+types with the `elm-street` library.
+
+### Records
+
+**Haskell**
+
+```haskell
+data User = User
+    { userName :: Text
+    , userAge  :: Int
+    }
+```
+
+**Elm**
+
+```elm
+type alias User =
+    { name : String
+    , age  : Int
+    }
+```
+
+### Enums
+
+**Haskell**
+
+```haskell
+data RequestStatus
+    = Approved
+    | Rejected
+    | Reviewing
+    deriving (Show, Read, Eq, Ord, Enum, Bounded)
+```
+
+**Elm**
+
+```elm
+type RequestStatus
+    = Approved
+    | Rejected
+    | Reviewing
+
+showRequestStatus : RequestStatus -> String
+showRequestStatus status = case status of
+    Approved  -> "Approved"
+    Rejected  -> "Rejected"
+    Reviewing -> "Reviewing"
+
+readRequestStatus : String -> Maybe RequestStatus
+readRequestStatus status = case status of
+    "Approved"  -> Just Approved
+    "Rejected"  -> Just Rejected
+    "Reviewing" -> Just Reviewing
+    _           -> Nothing
+
+universeRequestStatus : List RequestStatus
+universeRequestStatus = [Approved, Rejected, Reviewing]
+```
+
+### Newtypes
+
+**Haskell**
+
+```haskell
+newtype Size = Size { unSize :: Int }
+```
+
+**Elm**
+
+```elm
+type alias Size
+    { unSize : Int
+    }
+```
+
+### Newtypes with phantom types
+
+**Haskell**
+
+```haskell
+newtype Id a = Id { unId :: Text }
+```
+
+**Elm**
+
+```elm
+type Id a = Id String
+
+unId :: Id a -> String
+unId (Id id) = id
+```
+
+### Sum types
+
+**Haskell**
+
+```haskell
+data User
+    = Regular Text Int
+    | Visitor Text
+```
+
+**Elm**
+
+```elm
+type User
+    = Regular String Int
+    | Visitor String
+```


### PR DESCRIPTION
Resolves #1 

This PR contains examples of how Haskell types are converted to Elm types. Currently there are no examples for:

1. Recursive data types
2. Arbitrary polymorphic types

We don't use them currently, can add support later (I hope this won't be that difficult).

Let me know if this conversion makes sense! Or there're some ways to make it more convenient for fronted.

JSON decoders and encoders will be covered during #5 