### PR TITLE
[#17] Strip field name prefixes

### DIFF
--- a/.ghci
+++ b/.ghci
@@ -1,0 +1,4 @@
+:set -XTypeApplications
+import Data.Proxy
+import GHC.Generics
+import qualified Data.Text as T


### PR DESCRIPTION
Resolves #17 

I've checked in the `ghci`. Seems to work:

```haskell
λ: data User = User { userHeh :: String, userMeheh :: Int } deriving (Show, Generic)
λ: instance Elm User
λ: toElmDefinition (Proxy @User)
DefAlias (ElmAlias {elmAliasName = "User", elmAliasFields = ElmRecordField {elmRecordFieldType = TypeName {unTypeName = "[Char]"}, elmRecordFieldName = "heh"} :| [ElmRecordField {elmRecordFieldType = TypeName {unTypeName = "Int"}, elmRecordFieldName = "meheh"}]})
```