### PR TITLE
[#34] Better support of newtype encoders

### DIFF
--- a/stack-8.4.4.yaml
+++ b/stack-8.4.4.yaml
@@ -1,4 +1,0 @@
-resolver: lts-12.25
-
-ghc-options:
-  "$locals": -fhide-source-paths


### PR DESCRIPTION
Resolves #34 

> **NOTE:** additionally `!` were added to fields of all data types

Now there are `newtype`-specific encoders are generated. And AST keeps `isNewtype` flag so later it can be used for other improvements.

The idea here is to be able to use `deriving newtype (FromJSON, ToJSON)` in Haskell to get prettier and more efficient JSON instances.

### newtypes with phantoms

For data types with phantom type variables you need to write in Haskell the following:

```haskell
newtype Id a = Id { unId :: String }

instance Elm (Id a) where
    toElmDefinition _ = DefType $ ElmType "Id" ["a"] True $ ElmConstructor "Id" [RefPrim ElmString] :| []
```

Then the following Elm code is generated:

```elm
type Id a
    = Id String

unId : Id a -> String
unId (Id x) = x

encodeId : Id a -> Value
encodeId = E.string << unId
```

### Simple newtypes

For ordinary `newtypes`:

```haskell
newtype Size = Size
    { unSize :: Int
    } deriving (Generic)
      deriving anyclass (Elm)
```

The following will be generated:

```elm
type alias Size =
    { size : Int
    }

encodeSize : Size -> Value
encodeSize x = E.int x.size
```