### PR TITLE
[#38] Support decoders for newtypes

### DIFF
--- a/src/Elm/Print.hs
+++ b/src/Elm/Print.hs
@@ -555,7 +555,7 @@ typeDecoderDoc  t@ElmType{..} =
       where
         fieldDecoderDoc :: Doc ann
         fieldDecoderDoc = case elmConstructorFields $ NE.head elmTypeConstructors of
-            []    -> "ERROR"
+            []    -> "(D.fail \"Unknown field type of the newtype constructor\")"
             f : _ -> typeRefDecoder f
 
     sumDecoder :: Doc ann


### PR DESCRIPTION
Resolves #38

That was unexpectedly easy. Easier than with encoders. Also, thank you, @vrom911, for preparing `typeDecoderDoc`! It was quite easy to add `newtypeDecoder` there 🙂

Surprisingly, the decoders for both cases look the same:

```elm
type alias Size =
    { size : Int
    }
    
decodeSize : Decoder Size
decodeSize = JD.map Size JD.int

type Id a
    = Id String

decodeId : Decoder (Id a)
decodeId = JD.map Id JD.string
```