### PR TITLE
Drop support for phantom type variables

### DIFF
--- a/elm-example/src/Core/Decoder.elm
+++ b/elm-example/src/Core/Decoder.elm
@@ -22,7 +22,7 @@ decodePrims = D.succeed Prims
     |> required "pair" (elmStreetDecodePair elmStreetDecodeChar D.bool)
     |> required "list" (D.list D.int)
 
-decodeId : Decoder (Id a)
+decodeId : Decoder Id
 decodeId = D.map Id D.string
 
 decodeAge : Decoder Age
@@ -33,6 +33,7 @@ decodeRequestStatus = elmStreetDecodeEnum readRequestStatus
 
 decodeUser : Decoder User
 decodeUser = D.succeed User
+    |> required "id" decodeId
     |> required "name" D.string
     |> required "age" decodeAge
     |> required "status" decodeRequestStatus

--- a/elm-example/src/Core/Encoder.elm
+++ b/elm-example/src/Core/Encoder.elm
@@ -22,8 +22,8 @@ encodePrims x = E.object
     , ("list", E.list E.int x.list)
     ]
 
-encodeId : Id a -> Value
-encodeId = E.string << unId
+encodeId : Id -> Value
+encodeId x = E.string x.unId
 
 encodeAge : Age -> Value
 encodeAge x = E.int x.age
@@ -33,7 +33,8 @@ encodeRequestStatus = E.string << showRequestStatus
 
 encodeUser : User -> Value
 encodeUser x = E.object
-    [ ("name", E.string x.name)
+    [ ("id", encodeId x.id)
+    , ("name", E.string x.name)
     , ("age", encodeAge x.age)
     , ("status", encodeRequestStatus x.status)
     ]

--- a/elm-example/src/Core/Types.elm
+++ b/elm-example/src/Core/Types.elm
@@ -17,11 +17,9 @@ type alias Prims =
     , list : List Int
     }
 
-type Id a
-    = Id String
-
-unId : Id a -> String
-unId (Id x) = x
+type alias Id =
+    { unId : String
+    }
 
 type alias Age =
     { age : Int
@@ -49,7 +47,8 @@ universeRequestStatus : List RequestStatus
 universeRequestStatus = [Approved, Rejected, Reviewing]
 
 type alias User =
-    { name : String
+    { id : Id
+    , name : String
     , age : Age
     , status : RequestStatus
     }
@@ -60,7 +59,7 @@ type Guest
     | Blocked
 
 type alias UserRequest =
-    { ids : List (Id User)
+    { ids : List Id
     , limit : Int
     , example : Maybe (Result User Guest)
     }

--- a/types/Types.hs
+++ b/types/Types.hs
@@ -9,12 +9,10 @@ module Types
        ( Types
        ) where
 
-import Data.List.NonEmpty (NonEmpty (..))
 import Data.Text (Text)
 import Data.Time.Clock (UTCTime)
 import Data.Word (Word32)
-import Elm (Elm (..), ElmConstructor (..), ElmDefinition (..), ElmPrim (ElmString), ElmType (..),
-            TypeRef (..))
+import Elm (Elm (..), elmNewtype)
 import GHC.Generics (Generic)
 
 
@@ -38,9 +36,7 @@ newtype Id a = Id
     } deriving (Show)
 
 instance Elm (Id a) where
-    toElmDefinition _ = DefType
-        $ ElmType "Id" ["a"] True
-        $ ElmConstructor "Id" [RefPrim ElmString] :| []
+    toElmDefinition _ = elmNewtype @Text "Id" "unId"
 
 newtype Age = Age
     { unAge :: Int
@@ -55,8 +51,8 @@ data RequestStatus
     deriving anyclass (Elm)
 
 data User = User
-    -- { userId     :: Id User
-    { userName   :: Text
+    { userId     :: Id User
+    , userName   :: Text
     , userAge    :: Age
     , userStatus :: RequestStatus
     } deriving (Generic)


### PR DESCRIPTION
As discussed, phantom type variables were dropped. I didn't remove whole code regarding type variables, it still can be useful in future. Also I've created helper function for `instances`.