### PR TITLE
[#47] Custom error for constructors with >8 unnamed fields

### DIFF
--- a/src/Elm/Aeson.hs
+++ b/src/Elm/Aeson.hs
@@ -21,7 +21,8 @@ import GHC.Generics (Generic, Rep)
 import Type.Reflection (Typeable, typeRep)
 
 import Elm.Ast (TypeName (..))
-import Elm.Generic (Elm (..), GenericElmDefinition (..), HasNoTypeVars, stripTypeNamePrefix)
+import Elm.Generic (Elm (..), GenericElmDefinition (..), HasLessThanEightUnnamedFields,
+                    HasNoTypeVars, stripTypeNamePrefix)
 
 import qualified Data.Text as T
 import qualified GHC.Generics as Generic (from)
@@ -148,7 +149,11 @@ newtype ElmStreet a = ElmStreet
     { unElmStreet :: a
     }
 
-instance (HasNoTypeVars a, Generic a, GenericElmDefinition (Rep a)) => Elm (ElmStreet a) where
+instance ( HasNoTypeVars a
+         , HasLessThanEightUnnamedFields a
+         , Generic a
+         , GenericElmDefinition (Rep a)
+         ) => Elm (ElmStreet a) where
     toElmDefinition _ = genericToElmDefinition
         $ Generic.from (error "Proxy for generic elm was evaluated" :: a)
 


### PR DESCRIPTION
Resolves #47 

```haskell
> data User = User Int Int Int Int Int Int Int Int Int | Foo deriving (Generic) deriving anyclass (Elm)
> toElmDefinition $ Proxy @User

<interactive>:29:1: error:
    • 'elm-street' doesn't support Constructors with more than 8 unnamed fields.
      But 'User' has more.
    • In the expression: toElmDefinition $ Proxy @User
      In an equation for ‘it’: it = toElmDefinition $ Proxy @Use
```