### PR TITLE
[#74] Generated decoders for unit type does not compile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The changelog is available [on GitHub][2].
 
 ## Unreleased: 0.0.2.0
 
+* [#74](https://github.com/holmusk/elm-street/issues/74):
+  Fix unit type `typeRef` encoder and decoder printers.
 * [#72](https://github.com/holmusk/elm-street/issues/72):
   Use consistent encoders and decoders for unary constructors.
 

--- a/frontend/src/Core/Decoder.elm
+++ b/frontend/src/Core/Decoder.elm
@@ -22,6 +22,14 @@ decodePrims = D.succeed Prims
     |> required "pair" (elmStreetDecodePair elmStreetDecodeChar D.bool)
     |> required "list" (D.list D.int)
 
+decodeMyUnit : Decoder MyUnit
+decodeMyUnit =
+    let decide : String -> Decoder MyUnit
+        decide x = case x of
+            "MyUnit" -> D.field "contents" <| D.map MyUnit (D.map (always ()) (D.list D.string))
+            c -> D.fail <| "MyUnit doesn't have such constructor: " ++ c
+    in D.andThen decide (D.field "tag" D.string)
+
 decodeId : Decoder Id
 decodeId = D.map Id D.string
 
@@ -57,6 +65,7 @@ decodeUserRequest = D.succeed UserRequest
 decodeOneType : Decoder OneType
 decodeOneType = D.succeed OneType
     |> required "prims" decodePrims
+    |> required "myUnit" decodeMyUnit
     |> required "id" decodeId
     |> required "age" decodeAge
     |> required "requestStatus" decodeRequestStatus

--- a/frontend/src/Core/Encoder.elm
+++ b/frontend/src/Core/Encoder.elm
@@ -22,6 +22,10 @@ encodePrims x = E.object
     , ("list", E.list E.int x.list)
     ]
 
+encodeMyUnit : MyUnit -> Value
+encodeMyUnit x = E.object <| case x of
+    MyUnit x1 -> [("tag", E.string "MyUnit"), ("contents", (always <| E.list identity []) x1)]
+
 encodeId : Id -> Value
 encodeId x = E.string x.unId
 
@@ -55,6 +59,7 @@ encodeUserRequest x = E.object
 encodeOneType : OneType -> Value
 encodeOneType x = E.object
     [ ("prims", encodePrims x.prims)
+    , ("myUnit", encodeMyUnit x.myUnit)
     , ("id", encodeId x.id)
     , ("age", encodeAge x.age)
     , ("requestStatus", encodeRequestStatus x.requestStatus)

--- a/frontend/src/Core/Types.elm
+++ b/frontend/src/Core/Types.elm
@@ -17,6 +17,9 @@ type alias Prims =
     , list : List Int
     }
 
+type MyUnit
+    = MyUnit ()
+
 type alias Id =
     { unId : String
     }
@@ -66,6 +69,7 @@ type alias UserRequest =
 
 type alias OneType =
     { prims : Prims
+    , myUnit : MyUnit
     , id : Id
     , age : Age
     , requestStatus : RequestStatus

--- a/src/Elm/Print.hs
+++ b/src/Elm/Print.hs
@@ -611,7 +611,7 @@ typeDecoderDoc  t@ElmType{..} =
 typeRefDecoder :: TypeRef -> Doc ann
 typeRefDecoder (RefCustom TypeName{..}) = "decode" <> pretty (T.takeWhile (/= ' ') unTypeName)
 typeRefDecoder (RefPrim elmPrim) = case elmPrim of
-    ElmUnit       -> "(D.hardcoded ())"
+    ElmUnit       -> "(D.map (always ()) (D.list D.string))"
     ElmNever      -> "(D.fail \"Never is not possible\")"
     ElmBool       -> "D.bool"
     ElmChar       -> "elmStreetDecodeChar"

--- a/types/Types.hs
+++ b/types/Types.hs
@@ -104,9 +104,14 @@ data UserRequest = UserRequest
 instance ToJSON   UserRequest where toJSON = elmStreetToJson
 instance FromJSON UserRequest where parseJSON = elmStreetParseJson
 
+data MyUnit = MyUnit ()
+    deriving stock (Show, Eq, Ord, Generic)
+    deriving (Elm, ToJSON, FromJSON) via ElmStreet MyUnit
+
 -- | All test types together in one type to play with.
 data OneType = OneType
     { oneTypePrims         :: !Prims
+    , oneTypeMyUnit        :: !MyUnit
     , oneTypeId            :: !(Id OneType)
     , oneTypeAge           :: !Age
     , oneTypeRequestStatus :: !RequestStatus
@@ -122,6 +127,7 @@ instance FromJSON OneType where parseJSON = elmStreetParseJson
 -- | Type level list of all test types.
 type Types =
    '[ Prims
+    , MyUnit
     , Id ()
     , Age
     , RequestStatus
@@ -135,6 +141,7 @@ type Types =
 defaultOneType :: OneType
 defaultOneType = OneType
     { oneTypePrims = defaultPrims
+    , oneTypeMyUnit = MyUnit ()
     , oneTypeId = Id "myId"
     , oneTypeAge = Age 18
     , oneTypeRequestStatus = Reviewing

--- a/types/Types.hs
+++ b/types/Types.hs
@@ -106,7 +106,14 @@ instance FromJSON UserRequest where parseJSON = elmStreetParseJson
 
 data MyUnit = MyUnit ()
     deriving stock (Show, Eq, Ord, Generic)
-    deriving (Elm, ToJSON, FromJSON) via ElmStreet MyUnit
+#if ( __GLASGOW_HASKELL__ >= 806 )
+      deriving (Elm, ToJSON, FromJSON) via ElmStreet MyUnit
+#else
+      deriving anyclass Elm
+
+instance ToJSON   MyUnit where toJSON = elmStreetToJson
+instance FromJSON MyUnit where parseJSON = elmStreetParseJson
+#endif
 
 -- | All test types together in one type to play with.
 data OneType = OneType


### PR DESCRIPTION
Resolves #74

The problem with unit type is fix, however there is some other problem after the previous PR.
I'm clueless, I've been debugging this whole morning, but can't get why this happening: when making the POST request for `OneType` it fails with the error:

```
Error in $: parsing Types.OneType failed, key "tag" not present
```

I checked each field, seems it's not working with each of them, so I have no idea, why. Seems like the previous PR changed more than expected.