### PR TITLE
[#90] Support converting three-tuples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The changelog is available [on GitHub][2].
   Support GHC-8.6.5. Use common stanzas.
 * [#73](https://github.com/holmusk/elm-street/issues/73):
   Clarify the restriction with reserved words in documentation.
+* [#90](https://github.com/Holmusk/elm-street/issues/90)
+  Support converting 3-tuples
 
 ## 0.0.1 — Mar 29, 2019
 

--- a/frontend/src/Core/Decoder.elm
+++ b/frontend/src/Core/Decoder.elm
@@ -20,6 +20,7 @@ decodePrims = D.succeed T.Prims
     |> required "maybe" (nullable D.int)
     |> required "result" (elmStreetDecodeEither D.int D.string)
     |> required "pair" (elmStreetDecodePair elmStreetDecodeChar D.bool)
+    |> required "triple" (elmStreetDecodeTriple elmStreetDecodeChar D.bool D.int)
     |> required "list" (D.list D.int)
 
 decodeMyUnit : Decoder T.MyUnit

--- a/frontend/src/Core/ElmStreet.elm
+++ b/frontend/src/Core/ElmStreet.elm
@@ -16,6 +16,9 @@ elmStreetEncodeEither encA encB res = E.object <| case res of
 elmStreetEncodePair : (a -> Value) -> (b -> Value) -> (a, b) -> Value
 elmStreetEncodePair encA encB (a, b) = E.list identity [encA a, encB b]
 
+elmStreetEncodeTriple : (a -> Value) -> (b -> Value) -> (c -> Value) -> (a, b, c) -> Value
+elmStreetEncodeTriple encA encB encC (a, b, c) = E.list identity [encA a, encB b, encC c]
+
 decodeStr : (String -> Maybe a) -> String -> Decoder a
 decodeStr readX x = case readX x of
     Just a  -> D.succeed a
@@ -35,4 +38,7 @@ elmStreetDecodeEither decA decB = D.oneOf
 
 elmStreetDecodePair : Decoder a -> Decoder b -> Decoder (a, b)
 elmStreetDecodePair decA decB = D.map2 Tuple.pair (D.index 0 decA) (D.index 1 decB)
+
+elmStreetDecodeTriple : Decoder a -> Decoder b -> Decoder c -> Decoder (a, b, c)
+elmStreetDecodeTriple decA decB decC = D.map3 (\a b c -> (a,b,c)) (D.index 0 decA) (D.index 1 decB) (D.index 2 decC)
 

--- a/frontend/src/Core/Encoder.elm
+++ b/frontend/src/Core/Encoder.elm
@@ -20,6 +20,7 @@ encodePrims x = E.object
     , ("maybe", (elmStreetEncodeMaybe E.int) x.maybe)
     , ("result", (elmStreetEncodeEither E.int E.string) x.result)
     , ("pair", (elmStreetEncodePair (E.string << String.fromChar) E.bool) x.pair)
+    , ("triple", (elmStreetEncodeTriple (E.string << String.fromChar) E.bool E.int) x.triple)
     , ("list", E.list E.int x.list)
     ]
 

--- a/frontend/src/Core/Types.elm
+++ b/frontend/src/Core/Types.elm
@@ -14,6 +14,7 @@ type alias Prims =
     , maybe : Maybe Int
     , result : Result Int String
     , pair : (Char, Bool)
+    , triple : (Char, Bool, Int)
     , list : List Int
     }
 

--- a/frontend/tests/Tests.elm
+++ b/frontend/tests/Tests.elm
@@ -53,6 +53,7 @@ defaultOneType =
         , maybe  = Just 12
         , result = R.Err 666
         , pair   = ('o', False)
+        , triple = ('o', False, 0)
         , list   = [1, 2, 3, 4, 5]
         }
     , myUnit = MyUnit ()

--- a/frontend/tests/Tests/Golden.elm
+++ b/frontend/tests/Tests/Golden.elm
@@ -24,6 +24,11 @@ goldenOneTypeJson =
                 "o",
                 false
             ],
+            "triple": [
+                "o",
+                false,
+                0
+            ],
             "float": 36.6,
             "char": "a",
             "int": 42,

--- a/src/Elm/Ast.hs
+++ b/src/Elm/Ast.hs
@@ -72,18 +72,19 @@ getConstructorNames ElmType{..} = map elmConstructorName $ toList elmTypeConstru
 
 -- | Primitive elm types; hardcoded by the language.
 data ElmPrim
-    = ElmUnit                      -- ^ @()@ type in elm
-    | ElmNever                     -- ^ @Never@ type in elm, analogous to Void in Haskell
-    | ElmBool                      -- ^ @Bool@
-    | ElmChar                      -- ^ @Char@
-    | ElmInt                       -- ^ @Int@
-    | ElmFloat                     -- ^ @Float@
-    | ElmString                    -- ^ @String@
-    | ElmTime                      -- ^ @Posix@ in elm, @UTCTime@ in Haskell
-    | ElmMaybe !TypeRef            -- ^ @Maybe T@
-    | ElmResult !TypeRef !TypeRef  -- ^ @Result A B@ in elm
-    | ElmPair !TypeRef !TypeRef    -- ^ @(A, B)@ in elm
-    | ElmList !TypeRef             -- ^ @List A@ in elm
+    = ElmUnit                               -- ^ @()@ type in elm
+    | ElmNever                              -- ^ @Never@ type in elm, analogous to Void in Haskell
+    | ElmBool                               -- ^ @Bool@
+    | ElmChar                               -- ^ @Char@
+    | ElmInt                                -- ^ @Int@
+    | ElmFloat                              -- ^ @Float@
+    | ElmString                             -- ^ @String@
+    | ElmTime                               -- ^ @Posix@ in elm, @UTCTime@ in Haskell
+    | ElmMaybe !TypeRef                     -- ^ @Maybe T@
+    | ElmResult !TypeRef !TypeRef           -- ^ @Result A B@ in elm
+    | ElmPair !TypeRef !TypeRef             -- ^ @(A, B)@ in elm
+    | ElmTriple !TypeRef !TypeRef !TypeRef  -- ^ @(A, B, C)@ in elm
+    | ElmList !TypeRef                      -- ^ @List A@ in elm
     deriving (Show)
 
 -- | Reference to another existing type.

--- a/src/Elm/Generate.hs
+++ b/src/Elm/Generate.hs
@@ -22,8 +22,8 @@ import System.Directory (createDirectoryIfMissing)
 import System.FilePath ((<.>), (</>))
 
 import Elm.Generic (Elm (..))
-import Elm.Print (decodeChar, decodeEither, decodeEnum, decodePair, encodeEither, encodeMaybe,
-                  encodePair, prettyShowDecoder, prettyShowDefinition, prettyShowEncoder)
+import Elm.Print (decodeChar, decodeEither, decodeEnum, decodePair, decodeTriple, encodeEither, encodeMaybe,
+                  encodePair, encodeTriple, prettyShowDecoder, prettyShowDefinition, prettyShowEncoder)
 
 import qualified Data.Text as T
 import qualified Data.Text.IO as TIO
@@ -160,9 +160,11 @@ generateElm Settings{..} = do
         , encodeMaybe
         , encodeEither
         , encodePair
+        , encodeTriple
 
         , decodeEnum
         , decodeChar
         , decodeEither
         , decodePair
+        , decodeTriple
         ]

--- a/src/Elm/Generic.hs
+++ b/src/Elm/Generic.hs
@@ -134,6 +134,9 @@ instance (Elm a, Elm b) => Elm (Either a b) where
 instance (Elm a, Elm b) => Elm (a, b) where
     toElmDefinition _ = DefPrim $ ElmPair (elmRef @a) (elmRef @b)
 
+instance (Elm a, Elm b, Elm c) => Elm (a, b, c) where
+    toElmDefinition _ = DefPrim $ ElmTriple (elmRef @a) (elmRef @b) (elmRef @c)
+
 instance Elm a => Elm [a] where
     toElmDefinition _ = DefPrim $ ElmList (elmRef @a)
 

--- a/src/Elm/Print/Encoder.hs
+++ b/src/Elm/Print/Encoder.hs
@@ -9,6 +9,7 @@ module Elm.Print.Encoder
        , encodeMaybe
        , encodeEither
        , encodePair
+       , encodeTriple
        ) where
 
 import Data.List.NonEmpty (NonEmpty, toList)
@@ -170,18 +171,19 @@ encoderName typeName = "encode" <> pretty typeName
 typeRefEncoder :: TypeRef -> Doc ann
 typeRefEncoder (RefCustom TypeName{..}) = "encode" <> pretty (T.takeWhile (/= ' ') unTypeName)
 typeRefEncoder (RefPrim elmPrim) = case elmPrim of
-    ElmUnit       -> "(always <| E.list identity [])"
-    ElmNever      -> "never"
-    ElmBool       -> "E.bool"
-    ElmChar       -> parens "E.string << String.fromChar"
-    ElmInt        -> "E.int"
-    ElmFloat      -> "E.float"
-    ElmString     -> "E.string"
-    ElmTime       -> "Iso.encode"
-    ElmMaybe t    -> parens $ "elmStreetEncodeMaybe" <+> typeRefEncoder t
-    ElmResult l r -> parens $ "elmStreetEncodeEither" <+> typeRefEncoder l <+> typeRefEncoder r
-    ElmPair a b   -> parens $ "elmStreetEncodePair" <+> typeRefEncoder a <+> typeRefEncoder b
-    ElmList l     -> "E.list" <+> typeRefEncoder l
+    ElmUnit         -> "(always <| E.list identity [])"
+    ElmNever        -> "never"
+    ElmBool         -> "E.bool"
+    ElmChar         -> parens "E.string << String.fromChar"
+    ElmInt          -> "E.int"
+    ElmFloat        -> "E.float"
+    ElmString       -> "E.string"
+    ElmTime         -> "Iso.encode"
+    ElmMaybe t      -> parens $ "elmStreetEncodeMaybe" <+> typeRefEncoder t
+    ElmResult l r   -> parens $ "elmStreetEncodeEither" <+> typeRefEncoder l <+> typeRefEncoder r
+    ElmPair a b     -> parens $ "elmStreetEncodePair" <+> typeRefEncoder a <+> typeRefEncoder b
+    ElmTriple a b c -> parens $ "elmStreetEncodeTriple" <+> typeRefEncoder a <+> typeRefEncoder b <+> typeRefEncoder c
+    ElmList l       -> "E.list" <+> typeRefEncoder l
 
 -- | @JSON@ encoder Elm help function for 'Maybe's.
 encodeMaybe :: Text
@@ -199,9 +201,16 @@ encodeEither = T.unlines
     , "    Ok b  -> [(\"Right\", encB b)]"
     ]
 
--- | @JSON@ encoder Elm help function for tuples.
+-- | @JSON@ encoder Elm help function for 2-tuples.
 encodePair :: Text
 encodePair = T.unlines
     [ "elmStreetEncodePair : (a -> Value) -> (b -> Value) -> (a, b) -> Value"
     , "elmStreetEncodePair encA encB (a, b) = E.list identity [encA a, encB b]"
+    ]
+
+-- | @JSON@ encoder Elm help function for 3-tuples.
+encodeTriple :: Text
+encodeTriple = T.unlines
+    [ "elmStreetEncodeTriple : (a -> Value) -> (b -> Value) -> (c -> Value) -> (a, b, c) -> Value"
+    , "elmStreetEncodeTriple encA encB encC (a, b, c) = E.list identity [encA a, encB b, encC c]"
     ]

--- a/src/Elm/Print/Types.hs
+++ b/src/Elm/Print/Types.hs
@@ -97,18 +97,19 @@ display types of fields.
 -}
 elmPrimDoc :: ElmPrim -> Doc ann
 elmPrimDoc = \case
-    ElmUnit       -> "()"
-    ElmNever      -> "Never"
-    ElmBool       -> "Bool"
-    ElmChar       -> "Char"
-    ElmInt        -> "Int"
-    ElmFloat      -> "Float"
-    ElmString     -> "String"
-    ElmTime       -> "Posix"
-    ElmMaybe t    -> "Maybe" <+> elmTypeParenDoc t
-    ElmResult l r -> "Result" <+> elmTypeParenDoc l <+> elmTypeParenDoc r
-    ElmPair a b   -> lparen <> elmTypeRefDoc a <> comma <+> elmTypeRefDoc b <> rparen
-    ElmList l     -> "List" <+> elmTypeParenDoc l
+    ElmUnit         -> "()"
+    ElmNever        -> "Never"
+    ElmBool         -> "Bool"
+    ElmChar         -> "Char"
+    ElmInt          -> "Int"
+    ElmFloat        -> "Float"
+    ElmString       -> "String"
+    ElmTime         -> "Posix"
+    ElmMaybe t      -> "Maybe" <+> elmTypeParenDoc t
+    ElmResult l r   -> "Result" <+> elmTypeParenDoc l <+> elmTypeParenDoc r
+    ElmPair a b     -> lparen <> elmTypeRefDoc a <> comma <+> elmTypeRefDoc b <> rparen
+    ElmTriple a b c -> lparen <> elmTypeRefDoc a <> comma <+> elmTypeRefDoc b <> comma <+> elmTypeRefDoc c <> rparen
+    ElmList l       -> "List" <+> elmTypeParenDoc l
 
 {- | Pretty-printer for types. Adds parens for both sides when needed (when type
 contains of multiple words).

--- a/test/golden/oneType.json
+++ b/test/golden/oneType.json
@@ -19,6 +19,11 @@
             "o",
             false
         ],
+        "triple": [
+            "o",
+            false,
+            0
+        ],
         "float": 36.6,
         "char": "a",
         "int": 42,

--- a/types/Types.hs
+++ b/types/Types.hs
@@ -44,6 +44,7 @@ data Prims = Prims
     , primsMaybe  :: !(Maybe Word)
     , primsResult :: !(Either Int Text)
     , primsPair   :: !(Char, Bool)
+    , primsTriple :: !(Char, Bool, Int)
     , primsList   :: ![Int]
     } deriving (Generic, Eq, Show)
 #if ( __GLASGOW_HASKELL__ >= 806 )
@@ -179,6 +180,7 @@ defaultOneType = OneType
         , primsMaybe  = Just 12
         , primsResult = Left 666
         , primsPair   = ('o', False)
+        , primsTriple = ('o', False, 0)
         , primsList   = [1..5]
         }
 


### PR DESCRIPTION
This PR adds support for converting 3-tuples. This is the max number of tuples that elm supports and it makes sense for us to do so as well