### PR TITLE
[#6] Test Elm build on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,21 @@ matrix:
   - ghc: 8.6.5
     env: STACK_YAML="$TRAVIS_BUILD_DIR/stack.yaml"
 
+  # elm
+  - language: elm
+    cache:
+      directories:
+      - "$HOME/.npm"
+      - "$TRAVIS_BUILD_DIR/frontend/node_modules"
+      - "$TRAVIS_BUILD_DIR/frontend/elm-stuff"
+
+    install:
+      - cd frontend/
+      - npm install -g create-elm-app@2.2.0
+      - npm install
+    script:
+      - elm-app build
+
 install:
   - |
     if [ -z "$STACK_YAML" ]; then


### PR DESCRIPTION
Resolves #6

I haven't found any repository that builds Elm on Travis CI using `create-elm-app` :disappointed: 
So I just hope the following commands work...