### PR TITLE
Include GHC 8.8.4 and 8.10.2 in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,8 @@ matrix:
   # Cabal
   - ghc: 8.4.4
   - ghc: 8.6.5
-  - ghc: 8.8.3
+  - ghc: 8.8.4
+  - ghc: 8.10.2
 
   # stack
   - ghc: 8.4.4

--- a/elm-street.cabal
+++ b/elm-street.cabal
@@ -108,8 +108,8 @@ executable run-backend
   main-is:             Main.hs
   other-modules:       Api
 
-  build-depends:       servant >= 0.14 && < 0.18
-                     , servant-server >= 0.14 && < 0.18
+  build-depends:       servant >= 0.14 && < 0.19
+                     , servant-server >= 0.14 && < 0.19
                      , types
                      , wai ^>= 3.2
                      , warp < 3.4

--- a/elm-street.cabal
+++ b/elm-street.cabal
@@ -20,6 +20,8 @@ extra-doc-files:     README.md
                      CHANGELOG.md
 tested-with:         GHC == 8.4.4
                      GHC == 8.6.5
+                     GHC == 8.8.4
+                     GHC == 8.10.2
 
 source-repository head
   type:                git


### PR DESCRIPTION
Let's be a bit more future-proof before releasing to hackage.