### PR TITLE
Record fields list

### DIFF
--- a/frontend/src/Core/Decoder.elm
+++ b/frontend/src/Core/Decoder.elm
@@ -100,4 +100,4 @@ decodeOneType = D.succeed T.OneType
     |> required "recordUnit" decodeRecordUnit
 
 decodeRecordUnit : Decoder T.RecordUnit
-decodeRecordUnit = succeed {}
+decodeRecordUnit = D.succeed {}

--- a/frontend/src/Core/Decoder.elm
+++ b/frontend/src/Core/Decoder.elm
@@ -97,3 +97,7 @@ decodeOneType = D.succeed T.OneType
     |> required "user" decodeUser
     |> required "guests" (D.list decodeGuest)
     |> required "userRequest" decodeUserRequest
+    |> required "recordUnit" decodeRecordUnit
+
+decodeRecordUnit : Decoder T.RecordUnit
+decodeRecordUnit = succeed {}

--- a/frontend/src/Core/Encoder.elm
+++ b/frontend/src/Core/Encoder.elm
@@ -91,4 +91,8 @@ encodeOneType x = E.object
     , ("user", encodeUser x.user)
     , ("guests", (E.list encodeGuest) x.guests)
     , ("userRequest", encodeUserRequest x.userRequest)
+    , ("recordUnit", encodeRecordUnit x.recordUnit)
     ]
+
+encodeRecordUnit : T.RecordUnit -> Value
+encodeRecordUnit x = list (\_ -> null) []

--- a/frontend/src/Core/Types.elm
+++ b/frontend/src/Core/Types.elm
@@ -115,4 +115,8 @@ type alias OneType =
     , user : User
     , guests : List Guest
     , userRequest : UserRequest
+    , recordUnit : RecordUnit
     }
+
+type alias RecordUnit =
+    { }

--- a/frontend/tests/Tests.elm
+++ b/frontend/tests/Tests.elm
@@ -77,4 +77,5 @@ defaultOneType =
         , limit   = 123
         , example = Just (R.Ok Blocked)
         }
+    , recordUnit = {}
     }

--- a/frontend/tests/Tests/Golden.elm
+++ b/frontend/tests/Tests/Golden.elm
@@ -41,7 +41,7 @@ goldenOneTypeJson =
                 "objectField": {},
                 "arrayField": [1,2,3],
                 "nullField": null
-            }        
+            }
         },
         "myUnit": {
             "tag": "MyUnit",
@@ -92,6 +92,7 @@ goldenOneTypeJson =
             {
                 "tag": "Blocked"
             }
-        ]
+        ],
+        "recordUnit": []
     }
     """

--- a/src/Elm/Ast.hs
+++ b/src/Elm/Ast.hs
@@ -33,7 +33,7 @@ data ElmDefinition
 -- | AST for @record type alias@ in Elm.
 data ElmRecord = ElmRecord
     { elmRecordName      :: !Text  -- ^ Name of the record
-    , elmRecordFields    :: !(NonEmpty ElmRecordField)  -- ^ List of fields
+    , elmRecordFields    :: ![ElmRecordField]  -- ^ List of fields
     , elmRecordIsNewtype :: !Bool  -- ^ 'True' if Haskell type is a @newtype@
     } deriving (Show)
 

--- a/src/Elm/Ast.hs
+++ b/src/Elm/Ast.hs
@@ -5,7 +5,7 @@ converted to this AST which later is going to be pretty-printed.
 module Elm.Ast
        ( ElmDefinition (..)
 
-       , ElmAlias (..)
+       , ElmRecord (..)
        , ElmType (..)
        , ElmPrim (..)
 
@@ -25,19 +25,19 @@ import Data.Text (Text)
 
 -- | Elm data type definition.
 data ElmDefinition
-    = DefAlias !ElmAlias
-    | DefType  !ElmType
-    | DefPrim  !ElmPrim
+    = DefRecord !ElmRecord
+    | DefType   !ElmType
+    | DefPrim   !ElmPrim
     deriving (Show)
 
--- | AST for @type alias@ in Elm.
-data ElmAlias = ElmAlias
-    { elmAliasName      :: !Text  -- ^ Name of the alias
-    , elmAliasFields    :: !(NonEmpty ElmRecordField)  -- ^ List of fields
-    , elmAliasIsNewtype :: !Bool  -- ^ 'True' if Haskell type is a @newtype@
+-- | AST for @record type alias@ in Elm.
+data ElmRecord = ElmRecord
+    { elmRecordName      :: !Text  -- ^ Name of the record
+    , elmRecordFields    :: !(NonEmpty ElmRecordField)  -- ^ List of fields
+    , elmRecordIsNewtype :: !Bool  -- ^ 'True' if Haskell type is a @newtype@
     } deriving (Show)
 
--- | Single file of @type alias@.
+-- | Single field of @record type alias@.
 data ElmRecordField = ElmRecordField
     { elmRecordFieldType :: !TypeRef
     , elmRecordFieldName :: !Text
@@ -97,6 +97,6 @@ data TypeRef
 -- | Extracts reference to the existing data type type from some other type elm defintion.
 definitionToRef :: ElmDefinition -> TypeRef
 definitionToRef = \case
-    DefAlias ElmAlias{..} -> RefCustom $ TypeName elmAliasName
+    DefRecord ElmRecord{..} -> RefCustom $ TypeName elmRecordName
     DefType ElmType{..} -> RefCustom $ TypeName elmTypeName
     DefPrim elmPrim -> RefPrim elmPrim

--- a/src/Elm/Generic.hs
+++ b/src/Elm/Generic.hs
@@ -58,12 +58,12 @@ import Data.Time.Clock (UTCTime)
 import Data.Type.Bool (If, type (||))
 import Data.Void (Void)
 import Data.Word (Word16, Word32, Word8)
-import GHC.Generics ((:*:), (:+:), C1, Constructor (..), D1, Datatype (..), Generic (..), M1 (..),
-                     Meta (..), Rec0, S1, Selector (..), U1)
+import GHC.Generics (C1, Constructor (..), D1, Datatype (..), Generic (..), M1 (..), Meta (..),
+                     Rec0, S1, Selector (..), U1, (:*:), (:+:))
 import GHC.TypeLits (ErrorMessage (..), Nat, TypeError)
 import GHC.TypeNats (type (+), type (<=?))
 
-import Elm.Ast (ElmAlias (..), ElmConstructor (..), ElmDefinition (..), ElmPrim (..),
+import Elm.Ast (ElmConstructor (..), ElmDefinition (..), ElmPrim (..), ElmRecord (..),
                 ElmRecordField (..), ElmType (..), TypeName (..), TypeRef (..), definitionToRef)
 
 import qualified Data.Text as T
@@ -161,10 +161,10 @@ __instance__ Elm (Id a) __where__
 @
 -}
 elmNewtype :: forall a . Elm a => Text -> Text -> ElmDefinition
-elmNewtype typeName fieldName = DefAlias $ ElmAlias
-    { elmAliasName      = typeName
-    , elmAliasFields    = ElmRecordField (elmRef @a) fieldName :| []
-    , elmAliasIsNewtype = True
+elmNewtype typeName fieldName = DefRecord $ ElmRecord
+    { elmRecordName      = typeName
+    , elmRecordFields    = ElmRecordField (elmRef @a) fieldName :| []
+    , elmRecordIsNewtype = True
     }
 
 ----------------------------------------------------------------------------
@@ -182,7 +182,7 @@ class GenericElmDefinition (f :: k -> Type) where
 instance (Datatype d, GenericElmConstructors f) => GenericElmDefinition (D1 d f) where
     genericToElmDefinition datatype = case genericToElmConstructors (TypeName typeName) (unM1 datatype) of
         c :| [] -> case toElmConstructor c of
-            Left fields -> DefAlias $ ElmAlias typeName fields elmIsNewtype
+            Left fields -> DefRecord $ ElmRecord typeName fields elmIsNewtype
             Right ctor  -> DefType $ ElmType typeName [] elmIsNewtype (ctor :| [])
         c :| cs -> case traverse (rightToMaybe . toElmConstructor) (c :| cs) of
             -- TODO: this should be error but dunno what to do here

--- a/src/Elm/Print.hs
+++ b/src/Elm/Print.hs
@@ -21,7 +21,7 @@ import Data.List.NonEmpty
 
 test :: IO ()
 test = do
-    putStrLn $ T.unpack $ prettyShowDefinition $ DefAlias $ ElmAlias "User"  (ElmRecordField (RefPrim ElmString) "userHeh" :| [ElmRecordField (RefPrim ElmInt) "userMeh"]) False
+    putStrLn $ T.unpack $ prettyShowDefinition $ DefRecord $ ElmRecord "User"  (ElmRecordField (RefPrim ElmString) "userHeh" :| [ElmRecordField (RefPrim ElmInt) "userMeh"]) False
 
     --ENUM:
     putStrLn $ T.unpack $ prettyShowDefinition $ DefType $ ElmType "Status" [] False $ ElmConstructor "Approved" [] :| [ElmConstructor  "Yoyoyo" [], ElmConstructor "Wow" []]

--- a/src/Elm/Print/Decoder.hs
+++ b/src/Elm/Print/Decoder.hs
@@ -23,6 +23,7 @@ import Elm.Ast (ElmConstructor (..), ElmDefinition (..), ElmPrim (..), ElmRecord
 import Elm.Print.Common (arrow, mkQualified, qualifiedTypeWithVarsDoc, showDoc, wrapParens)
 
 import qualified Data.List.NonEmpty as NE
+import qualified Data.Maybe as Maybe
 import qualified Data.Text as T
 
 
@@ -83,13 +84,13 @@ recordDecoderDoc ElmRecord{..} =
   where
     newtypeDecoder :: Doc ann
     newtypeDecoder = name <+> "D.map" <+> qualifiedRecordName
-        <+> wrapParens (typeRefDecoder $ elmRecordFieldType $ NE.head elmRecordFields)
+        <+> wrapParens (Maybe.fromMaybe "ERROR" $ typeRefDecoder <$> elmRecordFieldType <$> Maybe.listToMaybe elmRecordFields)
 
     recordDecoder :: Doc ann
     recordDecoder = nest 4
         $ vsep
         $ (name <+> "D.succeed" <+> qualifiedRecordName)
-        : map fieldDecode (toList elmRecordFields)
+        : map fieldDecode elmRecordFields
 
     name :: Doc ann
     name = decoderName elmRecordName <+> equals

--- a/src/Elm/Print/Decoder.hs
+++ b/src/Elm/Print/Decoder.hs
@@ -18,7 +18,7 @@ import Data.Text (Text)
 import Data.Text.Prettyprint.Doc (Doc, colon, concatWith, dquotes, emptyDoc, equals, line, nest,
                                   parens, pretty, surround, vsep, (<+>))
 
-import Elm.Ast (ElmAlias (..), ElmConstructor (..), ElmDefinition (..), ElmPrim (..),
+import Elm.Ast (ElmConstructor (..), ElmDefinition (..), ElmPrim (..), ElmRecord (..),
                 ElmRecordField (..), ElmType (..), TypeName (..), TypeRef (..), isEnum)
 import Elm.Print.Common (arrow, mkQualified, qualifiedTypeWithVarsDoc, showDoc, wrapParens)
 
@@ -69,33 +69,33 @@ userDecoder =
 -}
 prettyShowDecoder :: ElmDefinition -> Text
 prettyShowDecoder def = showDoc $ case def of
-    DefAlias elmAlias -> aliasDecoderDoc elmAlias
-    DefType elmType   -> typeDecoderDoc elmType
-    DefPrim _         -> emptyDoc
+    DefRecord elmRecord -> recordDecoderDoc elmRecord
+    DefType elmType     -> typeDecoderDoc elmType
+    DefPrim _           -> emptyDoc
 
-aliasDecoderDoc :: ElmAlias -> Doc ann
-aliasDecoderDoc ElmAlias{..} =
-    decoderDef elmAliasName []
+recordDecoderDoc :: ElmRecord -> Doc ann
+recordDecoderDoc ElmRecord{..} =
+    decoderDef elmRecordName []
     <> line
-    <> if elmAliasIsNewtype
+    <> if elmRecordIsNewtype
        then newtypeDecoder
        else recordDecoder
   where
     newtypeDecoder :: Doc ann
-    newtypeDecoder = name <+> "D.map" <+> qualifiedAliasName
-        <+> wrapParens (typeRefDecoder $ elmRecordFieldType $ NE.head elmAliasFields)
+    newtypeDecoder = name <+> "D.map" <+> qualifiedRecordName
+        <+> wrapParens (typeRefDecoder $ elmRecordFieldType $ NE.head elmRecordFields)
 
     recordDecoder :: Doc ann
     recordDecoder = nest 4
         $ vsep
-        $ (name <+> "D.succeed" <+> qualifiedAliasName)
-        : map fieldDecode (toList elmAliasFields)
+        $ (name <+> "D.succeed" <+> qualifiedRecordName)
+        : map fieldDecode (toList elmRecordFields)
 
     name :: Doc ann
-    name = decoderName elmAliasName <+> equals
+    name = decoderName elmRecordName <+> equals
 
-    qualifiedAliasName :: Doc ann
-    qualifiedAliasName = mkQualified elmAliasName
+    qualifiedRecordName :: Doc ann
+    qualifiedRecordName = mkQualified elmRecordName
 
     fieldDecode :: ElmRecordField -> Doc ann
     fieldDecode ElmRecordField{..} = case elmRecordFieldType of

--- a/src/Elm/Print/Decoder.hs
+++ b/src/Elm/Print/Decoder.hs
@@ -85,8 +85,7 @@ recordDecoderDoc ElmRecord{..} =
        else recordDecoder
   where
     isEmptyRecord :: Bool
-    isEmptyRecord =
-        null elmRecordFields
+    isEmptyRecord = null elmRecordFields
 
     emptyRecordDecoder :: Doc ann
     emptyRecordDecoder = name <+> "D.succeed {}"

--- a/src/Elm/Print/Decoder.hs
+++ b/src/Elm/Print/Decoder.hs
@@ -83,8 +83,14 @@ recordDecoderDoc ElmRecord{..} =
        else recordDecoder
   where
     newtypeDecoder :: Doc ann
-    newtypeDecoder = name <+> "D.map" <+> qualifiedRecordName
-        <+> wrapParens (Maybe.fromMaybe "ERROR" $ typeRefDecoder <$> elmRecordFieldType <$> Maybe.listToMaybe elmRecordFields)
+    newtypeDecoder = name <+>
+        case typeRefDecoder <$> elmRecordFieldType <$> Maybe.listToMaybe elmRecordFields of
+          Just field ->
+                "D.map" <+> qualifiedRecordName
+                <+> wrapParens field
+          Nothing ->
+              "succeed {}"
+
 
     recordDecoder :: Doc ann
     recordDecoder = nest 4

--- a/src/Elm/Print/Encoder.hs
+++ b/src/Elm/Print/Encoder.hs
@@ -18,7 +18,7 @@ import Data.Text.Prettyprint.Doc (Doc, brackets, colon, comma, concatWith, dquot
                                   equals, lbracket, line, nest, parens, pretty, rbracket, surround,
                                   vsep, (<+>))
 
-import Elm.Ast (ElmAlias (..), ElmConstructor (..), ElmDefinition (..), ElmPrim (..),
+import Elm.Ast (ElmConstructor (..), ElmDefinition (..), ElmPrim (..), ElmRecord (..),
                 ElmRecordField (..), ElmType (..), TypeName (..), TypeRef (..), isEnum)
 import Elm.Print.Common (arrow, mkQualified, qualifiedTypeWithVarsDoc, showDoc, wrapParens)
 
@@ -40,9 +40,9 @@ TODO
 -}
 prettyShowEncoder :: ElmDefinition -> Text
 prettyShowEncoder def = showDoc $ case def of
-    DefAlias elmAlias -> aliasEncoderDoc elmAlias
-    DefType elmType   -> typeEncoderDoc elmType
-    DefPrim _         -> emptyDoc
+    DefRecord elmRecord -> recordEncoderDoc elmRecord
+    DefType elmType     -> typeEncoderDoc elmType
+    DefPrim _           -> emptyDoc
 
 -- | Encoder for 'ElmType' (which is either enum or the Sum type).
 typeEncoderDoc :: ElmType -> Doc ann
@@ -114,29 +114,29 @@ typeEncoderDoc t@ElmType{..} =
         vars =  concatWith (surround " ") fields
 
 
-aliasEncoderDoc :: ElmAlias -> Doc ann
-aliasEncoderDoc ElmAlias{..} =
-    encoderDef elmAliasName []
+recordEncoderDoc :: ElmRecord -> Doc ann
+recordEncoderDoc ElmRecord{..} =
+    encoderDef elmRecordName []
     <> line
-    <> if elmAliasIsNewtype
+    <> if elmRecordIsNewtype
        then newtypeEncoder
        else recordEncoder
   where
     newtypeEncoder :: Doc ann
-    newtypeEncoder = leftPart <+> fieldEncoderDoc (NE.head elmAliasFields)
+    newtypeEncoder = leftPart <+> fieldEncoderDoc (NE.head elmRecordFields)
 
     recordEncoder :: Doc ann
     recordEncoder = nest 4
         $ vsep
         $ (leftPart <+> "E.object")
-        : fieldsEncode elmAliasFields
+        : fieldsEncode elmRecordFields
 
     leftPart :: Doc ann
-    leftPart = encoderName elmAliasName <+> "x" <+> equals
+    leftPart = encoderName elmRecordName <+> "x" <+> equals
 
     fieldsEncode :: NonEmpty ElmRecordField -> [Doc ann]
     fieldsEncode fields =
-        lbracket <+> mkTag elmAliasName
+        lbracket <+> mkTag elmRecordName
       : map ((comma <+>) . recordFieldDoc) (NE.toList fields)
      ++ [rbracket]
 

--- a/src/Elm/Print/Encoder.hs
+++ b/src/Elm/Print/Encoder.hs
@@ -118,15 +118,26 @@ recordEncoderDoc :: ElmRecord -> Doc ann
 recordEncoderDoc ElmRecord{..} =
     encoderDef elmRecordName []
     <> line
-    <> if elmRecordIsNewtype
-       then newtypeEncoder
-       else recordEncoder
+    <>
+       if isEmptyRecord
+       then emptyRecordEncoder
+       else if elmRecordIsNewtype
+            then newtypeEncoder
+            else recordEncoder
   where
+    isEmptyRecord :: Bool
+    isEmptyRecord =
+        null elmRecordFields
+
     newtypeEncoder :: Doc ann
-    newtypeEncoder = leftPart <+>
+    newtypeEncoder =
         case fieldEncoderDoc <$> (Maybe.listToMaybe elmRecordFields) of
-          Just rightPart -> rightPart
-          Nothing -> "list (\\_ -> null) []"
+          Just rightPart -> leftPart <+> rightPart
+          Nothing        -> emptyRecordEncoder
+
+    emptyRecordEncoder :: Doc ann
+    emptyRecordEncoder =
+        leftPart <+> "list (\\_ -> null) []"
 
     recordEncoder :: Doc ann
     recordEncoder = nest 4

--- a/src/Elm/Print/Encoder.hs
+++ b/src/Elm/Print/Encoder.hs
@@ -68,7 +68,7 @@ typeEncoderDoc t@ElmType{..} =
       where
         fieldEncoderDoc :: Doc ann
         fieldEncoderDoc = case elmConstructorFields $ NE.head elmTypeConstructors of
-            []    -> "ERROR"
+            []    -> "{}"
             f : _ -> wrapParens (typeRefEncoder f)
 
     sumEncoder :: Doc ann
@@ -123,7 +123,10 @@ recordEncoderDoc ElmRecord{..} =
        else recordEncoder
   where
     newtypeEncoder :: Doc ann
-    newtypeEncoder = leftPart <+> Maybe.fromMaybe "ERROR" (fieldEncoderDoc <$> (Maybe.listToMaybe elmRecordFields))
+    newtypeEncoder = leftPart <+>
+        case fieldEncoderDoc <$> (Maybe.listToMaybe elmRecordFields) of
+          Just rightPart -> rightPart
+          Nothing -> "list (\\_ -> null) []"
 
     recordEncoder :: Doc ann
     recordEncoder = nest 4

--- a/src/Elm/Print/Encoder.hs
+++ b/src/Elm/Print/Encoder.hs
@@ -126,8 +126,7 @@ recordEncoderDoc ElmRecord{..} =
             else recordEncoder
   where
     isEmptyRecord :: Bool
-    isEmptyRecord =
-        null elmRecordFields
+    isEmptyRecord = null elmRecordFields
 
     newtypeEncoder :: Doc ann
     newtypeEncoder =
@@ -136,8 +135,7 @@ recordEncoderDoc ElmRecord{..} =
           Nothing        -> emptyRecordEncoder
 
     emptyRecordEncoder :: Doc ann
-    emptyRecordEncoder =
-        leftPart <+> "list (\\_ -> null) []"
+    emptyRecordEncoder = leftPart <+> "list (\\_ -> null) []"
 
     recordEncoder :: Doc ann
     recordEncoder = nest 4

--- a/src/Elm/Print/Encoder.hs
+++ b/src/Elm/Print/Encoder.hs
@@ -68,7 +68,7 @@ typeEncoderDoc t@ElmType{..} =
       where
         fieldEncoderDoc :: Doc ann
         fieldEncoderDoc = case elmConstructorFields $ NE.head elmTypeConstructors of
-            []    -> "{}"
+            []    -> "ERROR"
             f : _ -> wrapParens (typeRefEncoder f)
 
     sumEncoder :: Doc ann

--- a/src/Elm/Print/Encoder.hs
+++ b/src/Elm/Print/Encoder.hs
@@ -12,7 +12,6 @@ module Elm.Print.Encoder
        , encodeTriple
        ) where
 
-import Data.List.NonEmpty (NonEmpty, toList)
 import Data.Text (Text)
 import Data.Text.Prettyprint.Doc (Doc, brackets, colon, comma, concatWith, dquotes, emptyDoc,
                                   equals, lbracket, line, nest, parens, pretty, rbracket, surround,
@@ -23,6 +22,7 @@ import Elm.Ast (ElmConstructor (..), ElmDefinition (..), ElmPrim (..), ElmRecord
 import Elm.Print.Common (arrow, mkQualified, qualifiedTypeWithVarsDoc, showDoc, wrapParens)
 
 import qualified Data.List.NonEmpty as NE
+import qualified Data.Maybe as Maybe
 import qualified Data.Text as T
 
 
@@ -75,7 +75,7 @@ typeEncoderDoc t@ElmType{..} =
     sumEncoder = nest 4
         $ vsep
         $ (name <+> "x" <+> equals <+> "E.object <| case x of")
-        : map mkCase (toList elmTypeConstructors)
+        : map mkCase (NE.toList elmTypeConstructors)
 
     -- | Encoder function name
     name :: Doc ann
@@ -123,7 +123,7 @@ recordEncoderDoc ElmRecord{..} =
        else recordEncoder
   where
     newtypeEncoder :: Doc ann
-    newtypeEncoder = leftPart <+> fieldEncoderDoc (NE.head elmRecordFields)
+    newtypeEncoder = leftPart <+> Maybe.fromMaybe "ERROR" (fieldEncoderDoc <$> (Maybe.listToMaybe elmRecordFields))
 
     recordEncoder :: Doc ann
     recordEncoder = nest 4
@@ -134,10 +134,10 @@ recordEncoderDoc ElmRecord{..} =
     leftPart :: Doc ann
     leftPart = encoderName elmRecordName <+> "x" <+> equals
 
-    fieldsEncode :: NonEmpty ElmRecordField -> [Doc ann]
+    fieldsEncode :: [ElmRecordField] -> [Doc ann]
     fieldsEncode fields =
         lbracket <+> mkTag elmRecordName
-      : map ((comma <+>) . recordFieldDoc) (NE.toList fields)
+      : map ((comma <+>) . recordFieldDoc) fields
      ++ [rbracket]
 
     recordFieldDoc :: ElmRecordField -> Doc ann

--- a/src/Elm/Print/Types.hs
+++ b/src/Elm/Print/Types.hs
@@ -132,11 +132,13 @@ elmRecordDoc ElmRecord{..} = nest 4 $
     vsep $ ("type alias" <+> pretty elmRecordName <+> equals)
          : fieldsDoc elmRecordFields
   where
-    fieldsDoc :: NonEmpty ElmRecordField -> [Doc ann]
-    fieldsDoc (fstR :| rest) =
-        lbrace <+> recordFieldDoc fstR
-      : map ((comma <+>) . recordFieldDoc) rest
-     ++ [rbrace]
+    fieldsDoc :: [ElmRecordField] -> [Doc ann]
+    fieldsDoc = \case
+                [] -> [lbrace <+> rbrace]
+                fstR : rest ->
+                    lbrace <+> recordFieldDoc fstR
+                    : map ((comma <+>) . recordFieldDoc) rest
+                    ++ [rbrace]
 
     recordFieldDoc :: ElmRecordField -> Doc ann
     recordFieldDoc ElmRecordField{..} =

--- a/src/Elm/Print/Types.hs
+++ b/src/Elm/Print/Types.hs
@@ -54,7 +54,7 @@ module Elm.Print.Types
        ( prettyShowDefinition
 
          -- * Internal functions
-       , elmAliasDoc
+       , elmRecordDoc
        , elmTypeDoc
        ) where
 
@@ -64,7 +64,7 @@ import Data.Text.Prettyprint.Doc (Doc, align, colon, comma, dquotes, emptyDoc, e
                                   lparen, nest, parens, pipe, pretty, prettyList, rbrace, rparen,
                                   sep, space, vsep, (<+>))
 
-import Elm.Ast (ElmAlias (..), ElmConstructor (..), ElmDefinition (..), ElmPrim (..),
+import Elm.Ast (ElmConstructor (..), ElmDefinition (..), ElmPrim (..), ElmRecord (..),
                 ElmRecordField (..), ElmType (..), TypeName (..), TypeRef (..), getConstructorNames,
                 isEnum)
 import Elm.Print.Common (arrow, showDoc, typeWithVarsDoc, wrapParens)
@@ -74,7 +74,7 @@ import qualified Data.List.NonEmpty as NE
 
 {- | Pretty shows Elm types.
 
-* See 'elmAliasDoc' for examples of generated @type alias@.
+* See 'elmRecordDoc' for examples of generated @record type alias@.
 * See 'elmTypeDoc' for examples of generated @type@.
 -}
 prettyShowDefinition :: ElmDefinition -> Text
@@ -82,14 +82,14 @@ prettyShowDefinition = showDoc . elmDoc
 
 elmDoc :: ElmDefinition -> Doc ann
 elmDoc = \case
-    DefAlias elmAlias -> elmAliasDoc elmAlias
-    DefType elmType -> elmTypeDoc elmType
-    DefPrim _ -> emptyDoc
+    DefRecord elmRecord -> elmRecordDoc elmRecord
+    DefType elmType     -> elmTypeDoc elmType
+    DefPrim _           -> emptyDoc
 
 -- | Pretty printer for type reference.
 elmTypeRefDoc :: TypeRef -> Doc ann
 elmTypeRefDoc = \case
-    RefPrim elmPrim -> elmPrimDoc elmPrim
+    RefPrim elmPrim               -> elmPrimDoc elmPrim
     RefCustom (TypeName typeName) -> pretty typeName
 
 {- | Pretty printer for primitive Elm types. This pretty printer is used only to
@@ -118,7 +118,7 @@ consists of multiple words).
 elmTypeParenDoc :: TypeRef -> Doc ann
 elmTypeParenDoc = wrapParens . elmTypeRefDoc
 
-{- | Pretty printer for Elm aliases:
+{- | Pretty printer for Elm records:
 
 @
 type alias User =
@@ -127,10 +127,10 @@ type alias User =
     }
 @
 -}
-elmAliasDoc :: ElmAlias -> Doc ann
-elmAliasDoc ElmAlias{..} = nest 4 $
-    vsep $ ("type alias" <+> pretty elmAliasName <+> equals)
-         : fieldsDoc elmAliasFields
+elmRecordDoc :: ElmRecord -> Doc ann
+elmRecordDoc ElmRecord{..} = nest 4 $
+    vsep $ ("type alias" <+> pretty elmRecordName <+> equals)
+         : fieldsDoc elmRecordFields
   where
     fieldsDoc :: NonEmpty ElmRecordField -> [Doc ann]
     fieldsDoc (fstR :| rest) =

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-17.4
+resolver: lts-18.10

--- a/test/golden/oneType.json
+++ b/test/golden/oneType.json
@@ -36,7 +36,7 @@
             "objectField": {},
             "arrayField": [1,2,3],
             "nullField": null
-        }        
+        }
     },
     "myUnit": {
         "tag": "MyUnit",
@@ -87,5 +87,6 @@
         {
             "tag": "Blocked"
         }
-    ]
+    ],
+    "recordUnit": []
 }

--- a/types/Types.hs
+++ b/types/Types.hs
@@ -163,7 +163,7 @@ instance Elm RecordUnit where
     toElmDefinition _ = DefRecord $ ElmRecord
                             { elmRecordName = "RecordUnit"
                             , elmRecordFields = []
-                            , elmRecordIsNewtype = True
+                            , elmRecordIsNewtype = False
                             }
 
 

--- a/types/Types.hs
+++ b/types/Types.hs
@@ -27,12 +27,13 @@ module Types
        , UserRequest (..)
        ) where
 
-import Data.Aeson (FromJSON (..), ToJSON (..), Value(..), object, (.=))
+import Data.Aeson (FromJSON (..), ToJSON (..), Value (..), object, (.=))
 import Data.Text (Text)
 import Data.Time.Calendar (fromGregorian)
 import Data.Time.Clock (UTCTime (..))
 import Data.Word (Word32)
-import Elm (Elm (..), ElmStreet (..), elmNewtype, elmStreetParseJson, elmStreetToJson)
+import Elm (Elm (..), ElmDefinition (..), ElmRecord (..), ElmStreet (..), elmNewtype, elmStreetParseJson,
+            elmStreetToJson)
 import GHC.Generics (Generic)
 
 
@@ -148,11 +149,23 @@ instance FromJSON MyUnit where parseJSON = elmStreetParseJson
 data MyResult
     = Ok
     | Err Text
-    deriving (Generic, Eq, Show)
+    deriving stock (Generic, Eq, Show)
     deriving anyclass (Elm)
 
 instance ToJSON   MyResult where toJSON = elmStreetToJson
 instance FromJSON MyResult where parseJSON = elmStreetParseJson
+
+data RecordUnit = RecordUnit
+    deriving stock (Generic, Eq, Show)
+    deriving anyclass (FromJSON, ToJSON)
+
+instance Elm RecordUnit where
+    toElmDefinition _ = DefRecord $ ElmRecord
+                            { elmRecordName = "RecordUnit"
+                            , elmRecordFields = []
+                            , elmRecordIsNewtype = True
+                            }
+
 
 -- | All test types together in one type to play with.
 data OneType = OneType
@@ -168,6 +181,7 @@ data OneType = OneType
     , oneTypeUser           :: !User
     , oneTypeGuests         :: ![Guest]
     , oneTypeUserRequest    :: !UserRequest
+    , oneTypeRecordUnit     :: !RecordUnit
     } deriving (Generic, Eq, Show)
       deriving anyclass (Elm)
 
@@ -189,6 +203,7 @@ type Types =
     , Guest
     , UserRequest
     , OneType
+    , RecordUnit
     ]
 
 
@@ -206,6 +221,7 @@ defaultOneType = OneType
     , oneTypeUser = User (Id "1") "not-me" (Age 100) Approved
     , oneTypeGuests = [guestRegular, guestVisitor, guestBlocked]
     , oneTypeUserRequest = defaultUserRequest
+    , oneTypeRecordUnit = RecordUnit
     }
   where
     defaultPrims :: Prims


### PR DESCRIPTION
Support for `{}` records on elm side. This type of record is never derived by generics instance for it can be defined by hand. This makes representation of `ElmRecord` closer to real elm record and might become handy in the future. 