### PR TITLE
Mark Servant 0.19 as supported in the example

### DIFF
--- a/elm-street.cabal
+++ b/elm-street.cabal
@@ -109,8 +109,8 @@ executable run-backend
   main-is:             Main.hs
   other-modules:       Api
 
-  build-depends:       servant >= 0.14 && < 0.19
-                     , servant-server >= 0.14 && < 0.19
+  build-depends:       servant >= 0.14 && < 0.20
+                     , servant-server >= 0.14 && < 0.20
                      , types
                      , wai ^>= 3.2
                      , warp < 3.4

--- a/elm-street.cabal
+++ b/elm-street.cabal
@@ -109,8 +109,8 @@ executable run-backend
   main-is:             Main.hs
   other-modules:       Api
 
-  build-depends:       servant >= 0.14 && < 0.20
-                     , servant-server >= 0.14 && < 0.20
+  build-depends:       servant >= 0.14
+                     , servant-server >= 0.14
                      , types
                      , wai ^>= 3.2
                      , warp < 3.4


### PR DESCRIPTION
Just allow Servant 0.19 as a dependency for the example project.

Has no effect on the library itself. Stack is just disturbed by the example's dependencies whenever we try to depend on both elm-street and servant 0.19. Since the example does work with Servant 0.19, might as well include it in the version constraint.