### PR TITLE
Bump to 0.2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 The changelog is available [on GitHub][2].
 ## Unreleased
 
+## 0.2.0.0 - Mar 29, 2022
+
 * Remove GHC 8.4.4 and 8.6.5 from CI / tested-with
 * Add GHC 8.10.7, 9.0.2 and 9.2.2 to CI / tested-with
 * Support Json.Decode.Value as primitive

--- a/elm-street.cabal
+++ b/elm-street.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                elm-street
-version:             0.1.0.4
+version:             0.2.0.0
 synopsis:            Crossing the road between Haskell and Elm
 description:
     `Elm-street` allows you to generate automatically derived from Haskell types


### PR DESCRIPTION
I'd like to release the latest master to hackage.
Since some functionality was added and there are some changes in existing names,
according to [PVP](https://pvp.haskell.org/) we need at least major version bump