### PR TITLE
Allow building with GHC 9.8

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -14,17 +14,17 @@ jobs:
         os: [ubuntu-latest]
         cabal: ["3.10.1.0"]
         ghc:
-          - 8.10.7
           - 9.0.2
           - 9.2.8
-          - 9.4.6
-          - 9.6.2
+          - 9.4.8
+          - 9.6.3
+          - 9.8.1
         include:
           # Test only with latest GHC on windows and macOS
           - os: macOS-latest
-            ghc: 9.6.2
+            ghc: 9.8.1
           - os: windows-latest
-            ghc: 9.6.2
+            ghc: 9.8.1
 
     steps:
       - uses: actions/checkout@v3
@@ -63,8 +63,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        stack: [2.11.1]
-        ghc: [9.4.6]
+        stack: [2.13.1]
+        ghc: [9.4.8]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       matrix:
         stack: [2.13.1]
-        ghc: [9.4.8]
+        ghc: [9.6.3]
 
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 `elm-street` uses [PVP Versioning][1].
 The changelog is available [on GitHub][2].
 
+## 0.2.2.0 - Jan 4, 2024
+
+* Version bumps to allow building with GHC 9.8.1
+* Remove GHC 8.10.7 from CI
+
 ## 0.2.1.1 - Aug 3, 2023
 * Add missing extra-source-files: test/golden/oneType.json to cabal
 

--- a/elm-street.cabal
+++ b/elm-street.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                elm-street
-version:             0.2.1.1
+version:             0.2.2.0
 synopsis:            Crossing the road between Haskell and Elm
 description:
     `Elm-street` allows you to generate automatically derived from Haskell types
@@ -19,18 +19,18 @@ build-type:          Simple
 extra-doc-files:     README.md
                      CHANGELOG.md
 extra-source-files:  test/golden/oneType.json
-tested-with:         GHC == 8.10.7
-                     GHC == 9.0.2
+tested-with:         GHC == 9.0.2
                      GHC == 9.2.8
-                     GHC == 9.4.6
-                     GHC == 9.6.2
+                     GHC == 9.4.8
+                     GHC == 9.6.3
+                     GHC == 9.8.1
 
 source-repository head
   type:                git
   location:            https://github.com/Holmusk/elm-street.git
 
 common common-options
-  build-depends:       base >= 4.11.1.0 && < 4.19
+  build-depends:       base >= 4.11.1.0 && < 4.20
 
   ghc-options:         -Wall
                        -Wincomplete-uni-patterns

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-21.25
+resolver: lts-22.4

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-21.9
+resolver: lts-21.25


### PR DESCRIPTION
Upstream issue I'm trying to fix (to keep elm-street in stackage nightly)
https://github.com/commercialhaskell/stackage/issues/7215